### PR TITLE
Start a simple python webserver on 8443

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,0 +1,6 @@
+import BaseHTTPServer, SimpleHTTPServer
+import ssl
+
+httpd = BaseHTTPServer.HTTPServer(('localhost', 8443), SimpleHTTPServer.SimpleHTTPRequestHandler)
+httpd.socket = ssl.wrap_socket (httpd.socket, certfile='server.pem', server_side=True)
+httpd.serve_forever()


### PR DESCRIPTION
Uses the `.pem` generated by `openssl_pemgen.sh`